### PR TITLE
입력페이지 중첩 현상 해결

### DIFF
--- a/lib/pages/input_page.dart
+++ b/lib/pages/input_page.dart
@@ -36,7 +36,6 @@ class _InputPageState extends State<InputPage> {
   int step = 1;
   int testScore;
 
-
   @override
   void dispose() {
     _controller.dispose();
@@ -58,7 +57,7 @@ class _InputPageState extends State<InputPage> {
   }
 
   Widget stepActionButton(ArrowAction action, int step) {
-    final handleStep = (action == ArrowAction.up) ? (step-2) : (step);
+    final handleStep = (action == ArrowAction.up) ? (step - 2) : (step);
     String rowAction = (action == ArrowAction.up) ? "up" : "down";
     return FloatingActionButton(
       heroTag: rowAction,
@@ -76,7 +75,6 @@ class _InputPageState extends State<InputPage> {
   }
 
   renderStepButton(step) {
-
     final height = MediaQuery.of(context).size.height;
 
     return Container(
@@ -85,22 +83,21 @@ class _InputPageState extends State<InputPage> {
         mainAxisSize: MainAxisSize.max,
         children: <Widget>[
           Visibility(
-            visible: (step == 1 ) ? false : true,
+            visible: (step == 1) ? false : true,
             child: Align(
                 alignment: Alignment.topCenter,
-
                 child: Padding(
-                  padding:  EdgeInsets.only(top: height * 0.05 ),
+                  padding: EdgeInsets.only(top: height * 0.05),
                   child: stepActionButton(ArrowAction.up, step),
                 )),
           ),
           Visibility(
-            visible: (step == 3 ) ? false : true,
+            visible: (step == 3) ? false : true,
             child: Expanded(
               child: Align(
                   alignment: Alignment.bottomCenter,
                   child: Padding(
-                    padding:  EdgeInsets.only(bottom: height * 0.05 ),
+                    padding: EdgeInsets.only(bottom: height * 0.05),
                     child: stepActionButton(ArrowAction.down, step),
                   )),
             ),
@@ -128,8 +125,10 @@ class _InputPageState extends State<InputPage> {
               new FlatButton(
                 child: new Text("네"),
                 onPressed: () {
-                  Navigator.pushReplacement(context,
-                      MaterialPageRoute(builder: (context) => DailyPage()));
+                  Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(builder: (context) => DailyPage()),
+                      (e) => false);
                 },
               ),
             ],


### PR DESCRIPTION
아예 컴포넌트 자체를 메모리(스택)에서 지우는 경우(기기에서 제공하는 하단의 뒤로가기 버튼으로 돌아가게 하지 않는 경우)에는 변경안과 같은 함수를 사용
메모리(스택)에 남겨야하는 경우(기기에서 제공하는 하단의 뒤로가기 버튼으로 돌아갈 수 있게 하는 경우// 페이스북처럼)에는 이전 처럼 pushReplacement()를 이용