### PR TITLE
상단 스크롤 & 스텝 변경 시 스텝3의 데이터 초기화 버그 해결

### DIFF
--- a/lib/pages/input_page.dart
+++ b/lib/pages/input_page.dart
@@ -16,9 +16,6 @@ class InputPage extends StatefulWidget {
 
 class _InputPageState extends State<InputPage> {
   List emotions = [];
-
-  TextEditingController _textEditingController = TextEditingController();
-
   Color get backgroundColor {
     switch (step) {
       case 2:
@@ -195,6 +192,7 @@ class _InputPageState extends State<InputPage> {
     testScore = container.score;
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Container(
         color: backgroundColor,
         child: Stack(


### PR DESCRIPTION
키보드 레이아웃에 의한 버그로, 간헐적으로 보이던 데이터 초기화 현상도 연관이 큰 걸로 보입니다.